### PR TITLE
Rails 5 Support

### DIFF
--- a/app/controllers/new_relic_ping/health_controller.rb
+++ b/app/controllers/new_relic_ping/health_controller.rb
@@ -19,7 +19,8 @@ module NewRelicPing
 
     def send_response(status_msg, meta_info = {})
       write_headers(meta_info)
-      render :text => status_msg.to_s, :status => status_msg, :content_type => Mime::TEXT
+      content_type = (Rails::VERSION::MAJOR < 5 ? Mime::TEXT : Mime[:text])
+      render :text => status_msg.to_s, :status => status_msg, :content_type => content_type
     end
 
     def write_headers(values = {})

--- a/app/controllers/new_relic_ping/health_controller.rb
+++ b/app/controllers/new_relic_ping/health_controller.rb
@@ -20,7 +20,7 @@ module NewRelicPing
     def send_response(status_msg, meta_info = {})
       write_headers(meta_info)
       content_type = (Rails::VERSION::MAJOR < 5 ? Mime::TEXT : Mime[:text])
-      render :text => status_msg.to_s, :status => status_msg, :content_type => content_type
+      render :plain => status_msg.to_s, :status => status_msg, :content_type => content_type
     end
 
     def write_headers(values = {})


### PR DESCRIPTION
Hi, this pull request fixes Rails 5/Rails 5.1 deprecation warnings. It is tested to be working in my own app using the forked repo, however I haven't been able to get the tests working in the new_relic_ping code base since the dummy app is not Rails 5 compatible.

What do I need to do to get tests working? I'd love to get this merged as we use new_relic_ping in multiple apps (Rails 4 and Rails 5).

Thanks so much! 👍 